### PR TITLE
Virtualenv support

### DIFF
--- a/telenium/web.py
+++ b/telenium/web.py
@@ -413,8 +413,10 @@ class ApiWebSocket(WebSocket):
 
         # prepare the application
         entrypoint = self.session["settings"]["entrypoint"]
-        cmd = ["python", "-m", "telenium.execute", entrypoint]
+        cmd = [sys.executable, "-m", "telenium.execute", entrypoint]
         cwd = dirname(entrypoint)
+        if not os.path.isabs(cwd):
+            cwd = os.getcwd()
         env = os.environ.copy()
         env.update(self.session["env"])
         env["TELENIUM_TOKEN"] = telenium_token


### PR DESCRIPTION
Be able to start telenium-test from virtualenv (use python-exe from the virtualenv to launch the app). Check entrypoint for aboslute path: if it is not absolute (only 'main.py') we assume that we can use cwd() for the cwd value.

I do not know if you even accept PR's for this project, let me know. Really cool project btw!