### PR TITLE
Fixes missing parenthesis on print function (Python3)

### DIFF
--- a/telenium/tests.py
+++ b/telenium/tests.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import print_function
 
 import unittest
 import subprocess
@@ -106,7 +107,7 @@ class TeleniumTestCase(unittest.TestCase):
         subprocess.Popen(cmd_env).communicate()
         print("Execute: {}".format(cmd))
         cls.process = subprocess.Popen(cmd)
-        print cls.process.communicate()
+        print(cls.process.communicate())
 
     @classmethod
     def stop_process(cls):


### PR DESCRIPTION
Also make sure it doesn't happen again even on Python2, by importing
`print_function` from `__future__`.