### PR TITLE
Fix incorrect XPATH indexing in path_to method

### DIFF
--- a/telenium/mods/telenium_client.py
+++ b/telenium/mods/telenium_client.py
@@ -111,9 +111,11 @@ def path_to(widget):
     root = Window
     if widget.parent is root or widget.parent == widget or not widget.parent:
         return "/{}".format(widget.__class__.__name__)
+    filtered_children = [child for child in widget.parent.children if type(child) == type(widget)]
+    filtered_children.reverse()
     return "{}/{}[{}]".format(
         path_to(widget.parent), widget.__class__.__name__,
-        widget.parent.children.index(widget))
+        filtered_children.index(widget))
 
 
 def rpc_ping():


### PR DESCRIPTION
Hi, I've stumbled upon this (https://github.com/tito/telenium/issues/23) issue while checking out the library and noticed that there was no solution implemented despite an idea for a fix. So I implemented it locally and checked if it works. There was a need to reverse the filtered child list from what I had noticed during testing, so I implemented that too. 

Let me know if this PR is ok or if there is something that I should change.